### PR TITLE
Fix flow control configuration using incorrect flags

### DIFF
--- a/lib/sergensio_serialdev.c
+++ b/lib/sergensio_serialdev.c
@@ -740,7 +740,7 @@ termios_get_set_flowcontrol(struct termios *termio, int *mctl, int *ival)
     } else {
 	if (termio->c_cflag & CRTSCTS)
 	    *ival = SERGENSIO_FLOWCONTROL_RTS_CTS;
-	else if (termio->c_cflag & (IXON | IXOFF))
+	else if (termio->c_iflag & (IXON | IXOFF))
 	    *ival = SERGENSIO_FLOWCONTROL_XON_XOFF;
 	else
 	    *ival = SERGENSIO_FLOWCONTROL_NONE;

--- a/lib/sergensio_serialdev.c
+++ b/lib/sergensio_serialdev.c
@@ -720,15 +720,23 @@ termios_get_set_flowcontrol(struct termios *termio, int *mctl, int *ival)
     if (*ival) {
 	int val;
 
-	switch (*ival) {
-	case SERGENSIO_FLOWCONTROL_NONE: val = 0; break;
-	case SERGENSIO_FLOWCONTROL_XON_XOFF: val = IXON | IXOFF; break;
-	case SERGENSIO_FLOWCONTROL_RTS_CTS: val = CRTSCTS; break;
-	default:
-	    return GE_INVAL;
-	}
-	termio->c_cflag &= ~(IXON | IXOFF | CRTSCTS);
-	termio->c_cflag |= val;
+        switch (*ival) {
+        case SERGENSIO_FLOWCONTROL_NONE:
+                termio->c_iflag &= ~(IXON | IXOFF);
+                termio->c_cflag &= ~(CRTSCTS);
+                break;
+        case SERGENSIO_FLOWCONTROL_XON_XOFF:
+                termio->c_iflag |= (IXON | IXOFF);
+                termio->c_cflag &= ~(CRTSCTS);
+                break;
+        case SERGENSIO_FLOWCONTROL_RTS_CTS: val = CRTSCTS; break;
+                termio->c_iflag &= ~(IXON | IXOFF);
+                termio->c_cflag |= (CRTSCTS);
+                break;
+        default:
+            return GE_INVAL;
+        }
+
     } else {
 	if (termio->c_cflag & CRTSCTS)
 	    *ival = SERGENSIO_FLOWCONTROL_RTS_CTS;

--- a/lib/sergensio_serialdev.c
+++ b/lib/sergensio_serialdev.c
@@ -762,10 +762,10 @@ termios_get_set_iflowcontrol(struct termios *termio, int *mctl, int *ival)
 	default:
 	    return GE_INVAL;
 	}
-	termio->c_cflag &= ~IXOFF;
-	termio->c_cflag |= val;
+	termio->c_iflag &= ~IXOFF;
+	termio->c_iflag |= val;
     } else {
-	if (termio->c_cflag & IXOFF)
+	if (termio->c_iflag & IXOFF)
 	    *ival = SERGENSIO_FLOWCONTROL_XON_XOFF;
 	else
 	    *ival = SERGENSIO_FLOWCONTROL_NONE;


### PR DESCRIPTION
IXON and IXOFF were being incorrectly used on c_cflag instead of c_iflag. This meant that the CBAUDEX bit of c_cflag would get clobbered, preventing any access to baud rates above 38400.