### PR TITLE
lib/gensio_selector.c: fix definition of pthread_mutex_destroy

### DIFF
--- a/lib/gensio_selector.c
+++ b/lib/gensio_selector.c
@@ -29,7 +29,7 @@
 #define pthread_mutex_lock(l) do { } while (0)
 #define pthread_mutex_unlock(l) do { } while (0)
 #define pthread_mutex_init(l, n) do { } while (0)
-#define pthread_mutex_destroy(l, n) do { } while (0)
+#define pthread_mutex_destroy(l) do { } while (0)
 #define PTHREAD_MUTEX_INITIALIZER 0
 #endif
 


### PR DESCRIPTION
Fix definition of pthread_mutex_destroy otherwise build without threads
will fail on:

```
gensio_selector.c: In function 'gensio_sel_free_lock':
gensio_selector.c:82:38: error: macro "pthread_mutex_destroy" requires 2 arguments, but only 1 given
     pthread_mutex_destroy(&lock->lock);
                                      ^
gensio_selector.c:82:5: error: 'pthread_mutex_destroy' undeclared (first use in this function)
     pthread_mutex_destroy(&lock->lock);
     ^~~~~~~~~~~~~~~~~~~~~

```
Fixes:
 - http://autobuild.buildroot.org/results/b5847ac9e818571b746e2a81cf830b6caf50a7d7

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>