### PR TITLE
configure.ac: add --{dis,en}able-openssl option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -82,7 +82,14 @@ if test "x$HAVE_OPENIPMI" != "xno"; then
    AC_DEFINE([HAVE_OPENIPMI], [], [Have IPMI support through OpenIPMI])
 fi
 
-AX_CHECK_OPENSSL([AC_DEFINE([HAVE_OPENSSL], [], [Have SSL support through OpenSSL])])
+AC_ARG_ENABLE(openssl,
+[  --enable-openssl[[=yes|no]]       Enable or disable openssl.],
+[enable_openssl=$enableval], [enable_openssl=yes]
+)
+
+if test "x$enable_openssl" = "xyes"; then
+    AX_CHECK_OPENSSL([AC_DEFINE([HAVE_OPENSSL], [], [Have SSL support through OpenSSL])])
+fi
 
 tryswig=yes
 swigprog=


### PR DESCRIPTION
Allow the user to use --disable-openssl to disable openssl, this is
especially useful when cross-compiling for embedded targets as this will
avoid a build failure if openssl is found on the host

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>