### PR TITLE
configure.ac: add --with-tests option

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,8 +1,8 @@
 
 ACLOCAL_AMFLAGS = -I m4
 
-SUBDIRS = lib include $(SWIG_DIR) tests tools man examples
+SUBDIRS = lib include $(SWIG_DIR) $(TESTS_DIR) tools man examples
 
-DIST_SUBDIRS = lib swig include tests tools man examples
+DIST_SUBDIRS = lib swig include $(TESTS_DIR) tools man examples
 
 EXTRA_DIST = README.rst reconf

--- a/configure.ac
+++ b/configure.ac
@@ -145,6 +145,22 @@ AC_ARG_WITH(pythonusepthreads,
    fi,
 )
 
+TESTS_DIR=
+use_tests=yes
+AC_ARG_WITH(tests,
+[  --with-tests=yes|no      Build tests or not.],
+    if test "x$withval" = "xyes"; then
+      use_tests=yes
+    elif test "x$withval" = "xno"; then
+      use_tests=no
+    fi,
+)
+
+if test "x$use_tests" != "xno"; then
+   TESTS_DIR="tests"
+fi
+AC_SUBST(TESTS_DIR)
+
 AC_SEARCH_LIBS([clock_gettime], [rt posix4])
 
 # Handle RS485 support


### PR DESCRIPTION
Allow the user to disable tests through --without-tests, this is
especially useful on embedded systems

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>