### PR TITLE
tests/Makefile.am: don't add -lpthread

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -127,7 +127,7 @@ test_fuzz: test_fuzz_certauth test_fuzz_mux test_fuzz_ssl test_fuzz_telnet \
 
 oomtest_SOURCES = oomtest.c
 
-oomtest_LDADD = $(top_builddir)/lib/libgensio.la $(OPENSSL_LIBS) -lpthread
+oomtest_LDADD = $(top_builddir)/lib/libgensio.la $(OPENSSL_LIBS)
 
 noinst_PROGRAMS = oomtest
 


### PR DESCRIPTION
Don't add -lpthread unconditionally to oomtest_LDADD to avoid a build
failure without threads, it will be added to LIBS by configure.ac if
needed

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>