### PR TITLE
Add libgensio.pc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -267,6 +267,7 @@ if test "x$enable_internal_trace" != xno; then
 fi
 
 AC_OUTPUT([Makefile
+	lib/libgensio.pc
 	lib/Makefile
 	include/Makefile
 	include/gensio/Makefile

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -25,3 +25,8 @@ libgensio_la_SOURCES = \
 libgensio_la_LDFLAGS = $(OPENSSL_LIBS)
 
 EXTRA_DIST = README.rst
+
+# This variable must have 'exec' in its name, in order to be installed
+# by 'install-exec' target (instead of default 'install-data')
+pkgconfigexecdir = $(libdir)/pkgconfig
+pkgconfigexec_DATA = libgensio.pc

--- a/lib/libgensio.pc.in
+++ b/lib/libgensio.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: libgensio
+Description: A library to abstract stream I/O like serial port, TCP, telnet, UDP, SSL, IPMI SOL, etc. 
+Version: @VERSION@
+Libs: -L${libdir} -lgensio
+Libs.private: @OPENSSL_LIBS@


### PR DESCRIPTION
gensio can optionally depends on openssl so add libgensio.pc to allow
packages (such as ser2net) that link statically with gensio to use
pkg-config to retrieve those static dependencies

For example, this will avoid the following build failure on ser2net:

```
checking gensio/gensio.h usability... yes
checking gensio/gensio.h presence... yes
checking for gensio/gensio.h... yes
checking for str_to_gensio in -lgensio... no
configure: error: libgensio won't link, please install gensio dev package
```

Fixes:
 - http://autobuild.buildroot.org/results/f15cf961ddaf849987afce01ede0e3d1e77a0fc0

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>