### PR TITLE
Fix macOS compilation errors

### DIFF
--- a/include/gensio/selector.h
+++ b/include/gensio/selector.h
@@ -8,6 +8,10 @@
 #ifndef SELECTOR
 #define SELECTOR
 #include <sys/time.h> /* For timeval */
+#ifdef __APPLE__
+#include <signal.h>
+#define EBADFD 77
+#endif
 
 #if defined _WIN32 || defined __CYGWIN__
   #ifdef BUILDING_DLL

--- a/lib/gensio_selector.c
+++ b/lib/gensio_selector.c
@@ -6,7 +6,9 @@
  */
 
 #include "config.h"
+#ifndef __APPLE__
 #include <malloc.h>
+#endif
 #include <string.h>
 #include <errno.h>
 

--- a/tools/utils.c
+++ b/tools/utils.c
@@ -8,7 +8,9 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <ctype.h>
+#ifndef __APPLE__
 #include <malloc.h>
+#endif
 #include <string.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
- `<signal.h>` is required for `sigset_t`
- `<errno.h>` does not define `EBADFD` on macOS
- `<malloc.h>` is `<malloc/malloc.h>` on macOS but it's not required to use `malloc()`