### PR TITLE
additional spelling fixes

### DIFF
--- a/lib/mdns.c
+++ b/lib/mdns.c
@@ -354,7 +354,7 @@ avahi_add_service(struct gensio_mdns *m, struct gensio_mdns_service *s)
     err = avahi_entry_group_commit(s->group);
     if (err)
 	gensio_mdns_log(m, GENSIO_LOG_ERR,
-			"Error commiting service entry: %s",
+			"Error committing service entry: %s",
 			avahi_strerror(err));
 }
 

--- a/man/gensio.5
+++ b/man/gensio.5
@@ -34,7 +34,7 @@ specifies a telnet filter on top of a TCP connection.
 
 When specifying a gensio, you can add quotes (single or double) to
 remove the special meaning for some characters, so you can have commas
-in options and such.  They may also be escaped with a "\\".  For instance,
+in options and such.  They may also be escaped with a "\e".  For instance,
 if you are specifying a laddr in an sctp address, you need to do this.
 The following address:
 .IP
@@ -766,7 +766,7 @@ The remote address string is either "stdio,<args>" for the main channel or
 "stderr,<args>" for the error channel.  The args will be a set of quoted
 strings with a space between each string, one for each argument,
 with '"' around each argument, each '"' in the string converted
-to '\\"' and each '\\' in the string converted to '\\\\'.
+to '\e"' and each '\e' in the string converted to '\e\e'.
 .SS "Remote ID"
 The remote ID is the pid for the remote device, only for connecting
 gensios that start a program, not for any other type.
@@ -1307,8 +1307,8 @@ Set the group of the slave pty to the given group.
 The remote address string the program and arguments run on the pty.
 The argiuments will be a set of quoted strings with a space between each
 string, one for each argument, with '"' around each argument, each '"'
-in the string converted to '\\"' and each '\\' in the string
-converted to '\\\\'.
+in the string converted to '\e"' and each '\e' in the string
+converted to '\e\e'.
 .SS "Remote Address"
 The address is a pointer to an integer, the ptym file descriptor is
 returned.  addrlen must be set to sizeof(int) when passed in.

--- a/tests/oomtest.c
+++ b/tests/oomtest.c
@@ -2185,7 +2185,7 @@ main(int argc, char *argv[])
 
     if (use_glib) {
 #ifndef HAVE_GLIB
-	fprintf(stderr, "glib specified, but glib OS handler not avaiable.\n");
+	fprintf(stderr, "glib specified, but glib OS handler not available.\n");
 	exit(1);
 #else
 	os_func_str = " --glib";
@@ -2193,7 +2193,7 @@ main(int argc, char *argv[])
 #endif
     } else if (use_tcl) {
 #ifndef HAVE_TCL
-	fprintf(stderr, "tcl specified, but tcl OS handler not avaiable.\n");
+	fprintf(stderr, "tcl specified, but tcl OS handler not available.\n");
 	exit(1);
 #else
 	if (num_extra_threads > 0)

--- a/tools/gensiotool.c
+++ b/tools/gensiotool.c
@@ -896,14 +896,14 @@ main(int argc, char *argv[])
 
     if (use_glib) {
 #ifndef HAVE_GLIB
-	fprintf(stderr, "glib specified, but glib OS handler not avaiable.\n");
+	fprintf(stderr, "glib specified, but glib OS handler not available.\n");
 	exit(1);
 #else
 	rv = gensio_glib_funcs_alloc(&g.o);
 #endif
     } else if (use_tcl) {
 #ifndef HAVE_TCL
-	fprintf(stderr, "tcl specified, but tcl OS handler not avaiable.\n");
+	fprintf(stderr, "tcl specified, but tcl OS handler not available.\n");
 	exit(1);
 #else
 	if (num_extra_threads > 0)

--- a/tools/gtlssh-keygen.c
+++ b/tools/gtlssh-keygen.c
@@ -136,7 +136,7 @@ help(const char *progname)
     P("    Put the local certificate for the given host onto the remote\n");
     P("    host so it can be used for login.  It uses old credentials\n");
     P("    (credentials with .1 appended to the name, per keygen) if\n");
-    P("    they are there.  This is useful if you have upated your\n");
+    P("    they are there.  This is useful if you have updated your\n");
     P("    certificate and need to send a new one to some remote hosts.\n");
     P("    It finds the certificate name as described in the keygen\n");
     P("    command.  If old credentials exist, it will use those to\n");


### PR DESCRIPTION
Here are a few additional spelling fixes uncovered by Lintian.

In a manpage, a backslash is emitted by \e. \\ works too, but gives ambiguity with \' which is an accent acute.

Greetings
Marc
