### PR TITLE
tools:gensiot: Fix build with musl

### DIFF
--- a/tools/gensiotool.c
+++ b/tools/gensiotool.c
@@ -44,7 +44,7 @@
 #include <signal.h>
 #include <errno.h>
 #include <sys/types.h>
-#include <sys/unistd.h>
+#include <unistd.h>
 #include <syslog.h>
 #endif
 


### PR DESCRIPTION
According to POSIX getpid() is available in unistd.h, not sys/unistd.h.

Signed-off-by: Jan Luebbe <jlu@pengutronix.de>