### PR TITLE
configure: Check for request_init API when probing for libwrap

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -109,7 +109,7 @@ AC_ARG_WITH(tcp-wrappers,
 if test "$tcp_wrappers" != "no"
 then
   AC_CHECK_HEADERS([tcpd.h])
-  AC_CHECK_LIB(wrap,main)
+  AC_CHECK_LIB(wrap,request_init)
 fi
 
 AC_ARG_ENABLE([doc],


### PR DESCRIPTION
checking for main() is not right check, since this function is not part
of libwrap but the app. Newer autocof and toolchain may fail

Signed-off-by: Khem Raj <raj.khem@gmail.com>