### PR TITLE
Add GitHub action for Windows builds

### DIFF
--- a/.github/workflows/winbuild.yml
+++ b/.github/workflows/winbuild.yml
@@ -1,0 +1,48 @@
+name: WinBuild
+on: 
+  push:
+    branches:
+      - 'master'
+    tags:
+      - v*
+
+jobs:
+  mingw-build:
+    strategy:
+      matrix:
+        include:
+          - { sys: mingw64, env: x86_64 }
+          - { sys: mingw32, env: i686 }
+    
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{matrix.sys}}
+          update: true
+          install: >-
+            git 
+            mingw-w64-${{matrix.env}}-gcc 
+            mingw-w64-${{matrix.env}}-openssl 
+            mingw-w64-${{matrix.env}}-python 
+            libtool 
+            autotools 
+            swig
+      - name: MSBuild
+        run: |
+          ./reconf
+          ./configure
+          make
+      - name: Upload binaries from lib and tools
+        uses: actions/upload-artifact@v3
+        with:
+          name: gensio-mingw-${{matrix.env}}
+          path: |
+            lib/.libs/*.dll
+            lib/.libs/*.a
+            lib/.libs/*.la
+            tools/*.exe


### PR DESCRIPTION
References #25 

This workflow builds 32 bit and 64 bit Windows binaries with mingw and packs all `*.dll`, `*.a` and `*.la` lib files as well as the `*.exe` files of the tools folder into zip artifacts. The job will be run at every `master` push or when creating a release tag named `v*`. The repository must be configured to allow the `msys2/setup-msys2@v2` action to make it work properly.

Please see this PR as a proposal. We will need these binaries in our projects and I just wanted to share the code with you. So feel free to make change requests, reject or approve this PR.
