### PR TITLE
Fix missing EVP_PKEY_ED25519 build error on libressl

### DIFF
--- a/lib/gensio_filter_certauth.c
+++ b/lib/gensio_filter_certauth.c
@@ -835,11 +835,13 @@ v3_certauth_add_challenge_rsp(struct certauth_filter *sfilter)
     unsigned int lenpos, len;
     int rv = 0;
 
+#ifdef EVP_PKEY_ED25519
     if (EVP_PKEY_base_id(sfilter->pkey) == EVP_PKEY_ED25519) {
 	gca_log_err(sfilter,
 		    "Remote end or SSL too old to support ed25519 key");
 	return GE_KEYINVALID;
     }
+#endif
 
     certauth_write_byte(sfilter, CERTAUTH_CHALLENGE_RSP);
     lenpos = sfilter->write_buf_len;
@@ -898,8 +900,10 @@ certauth_add_challenge_rsp(struct certauth_filter *sfilter)
     if (sfilter->version < 4 || sfilter->my_version < 4)
 	return v3_certauth_add_challenge_rsp(sfilter);
 
+#ifdef EVP_PKEY_ED25519
     if (EVP_PKEY_base_id(sfilter->pkey) == EVP_PKEY_ED25519)
 	digest = NULL;
+#endif
 
     certauth_write_byte(sfilter, CERTAUTH_CHALLENGE_RSP);
     lenpos = sfilter->write_buf_len;
@@ -1045,8 +1049,10 @@ certauth_check_challenge(struct certauth_filter *sfilter)
 	goto out_nomem;
     }
 
+#ifdef EVP_PKEY_ED25519
     if (EVP_PKEY_base_id(pkey) == EVP_PKEY_ED25519)
 	digest = NULL;
+#endif
 
     if (!EVP_DigestVerifyInit(sign_ctx, NULL, digest, NULL, pkey)) {
 	gca_logs_err(sfilter, "Digest verify init failed");

--- a/tools/gtlssh-keygen.c
+++ b/tools/gtlssh-keygen.c
@@ -108,7 +108,12 @@ help(const char *progname)
     P("        The default is your username for normal certificates and\n");
     P("        the fully qualified domain name for server certificates.\n");
     P("  --algorithm <algname> - Set the algorithm to use for the key,\n");
-    P("        either ed25519, rsa or ec.  The default is ed25519.\n");
+    P("        either ed25519, rsa or ec.  ");
+#ifdef EVP_PKEY_ED25519
+    P("The default is ed25519.\n");
+#else
+    P("The default is ec.\n");
+#endif
     P("  --force, -f - Don't ask questions, just do the operation.  This\n");
     P("        may overwrite data without asking.\n");
     P("  --version - Print the version number and exit.\n");
@@ -831,7 +836,11 @@ genpkey_ed25519(const char *key)
     return rc != 0;
 }
 
+#ifdef EVP_PKEY_ED25519
 static int (*genpkey)(const char *key) = genpkey_ed25519;
+#else
+static int (*genpkey)(const char *key) = genpkey_ec;
+#endif
 
 /*
  * Create a single key.  If name is NULL, it's a server key, otherwise


### PR DESCRIPTION
Fixes:
```c
gensio_filter_certauth.c: In function ‘v3_certauth_add_challenge_rsp’: gensio_filter_certauth.c:838:44: error: ‘EVP_PKEY_ED25519’ undeclared (first use in this function); did you mean ‘EVP_PKEY_DSA1’?
  838 |     if (EVP_PKEY_base_id(sfilter->pkey) == EVP_PKEY_ED25519) {
      |                                            ^~~~~~~~~~~~~~~~
      |                                            EVP_PKEY_DSA1
gensio_filter_certauth.c:838:44: note: each undeclared identifier is reported only once for each function it appears in
gensio_filter_certauth.c: In function ‘certauth_add_challenge_rsp’:
gensio_filter_certauth.c:901:44: error: ‘EVP_PKEY_ED25519’ undeclared (first use in this function); did you mean ‘EVP_PKEY_DSA1’?
  901 |     if (EVP_PKEY_base_id(sfilter->pkey) == EVP_PKEY_ED25519)
      |                                            ^~~~~~~~~~~~~~~~
      |                                            EVP_PKEY_DSA1
gensio_filter_certauth.c: In function ‘certauth_check_challenge’:
gensio_filter_certauth.c:1048:35: error: ‘EVP_PKEY_ED25519’ undeclared (first use in this function); did you mean ‘EVP_PKEY_DSA1’?
 1048 |     if (EVP_PKEY_base_id(pkey) == EVP_PKEY_ED25519)
      |                                   ^~~~~~~~~~~~~~~~
      |                                   EVP_PKEY_DSA1
```