### PR TITLE
Some macOS 11+ fixes

### DIFF
--- a/lib/gensio_ll_sound.c
+++ b/lib/gensio_ll_sound.c
@@ -31,10 +31,18 @@
 #define IS_LITTLE_ENDIAN (__BYTE_ORDER != __BIG_ENDIAN)
 
 #else /* BSD and others? */
+#if defined(__APPLE__)
+#include <machine/endian.h>
+#include <libkern/OSByteOrder.h>
+#define bswap_16 OSSwapInt16
+#define bswap_32 OSSwapInt32
+#define bswap_64 OSSwapInt64
+#else
 #include <sys/endian.h>
 #define bswap_16 bswap16
 #define bswap_32 bswap32
 #define bswap_64 bswap64
+#endif
 #define IS_BIG_ENDIAN (BYTE_ORDER == BIG_ENDIAN)
 #define IS_LITTLE_ENDIAN (BYTE_ORDER != BIG_ENDIAN)
 #endif


### PR DESCRIPTION
For your consideration, @cminyard.

These are some tweaks that I made to get the package building on macOS 11.

The endian fix wasn't necessary in 2.5.1, but seems like it is needed in 2.5.3+.

The sigtimedwait fix wasn't necessary in macOS 10.12, but it appears this function no longer exists in macOS 11, so I implemented a hack-around inspired by https://sourceware.org/pipermail/gdb-cvs/2021-July/051027.html

I'm not sure the `sigtimedwait` fix is ready since I haven't really tested specifically, but I'm not yet observing ill effects.