### PR TITLE
#ifndef HAVE_SIGTIMEDWAIT (macOS support)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1738,6 +1738,7 @@ AC_CHECK_FUNCS(strcasecmp)
 AC_CHECK_FUNCS(strncasecmp)
 AC_CHECK_FUNCS(prctl)
 AC_CHECK_FUNCS(setutxent)
+AC_CHECK_FUNCS(sigtimedwait)
 
 AC_CHECK_DECLS([SIGWINCH], [], [], [#include <signal.h>])
 

--- a/tests/runtest.in
+++ b/tests/runtest.in
@@ -54,10 +54,13 @@ fi
 
 if ${PYTHON_MODE}; then
     export PYTHONPATH=${BUILDDIR}/swig/python:${BUILDDIR}/swig/python/.libs:${BUILDDIR}/glib/swig/python:${BUILDDIR}/glib/swig/python/.libs:${BUILDDIR}/tcl/swig/python:${BUILDDIR}/tcl/swig/python/.libs:${TEST_BUILDDIR}
+    # set the mach dylib path for mac
+    if [ `uname` == "Darwin" ]; then
+	export DYLD_LIBRARY_PATH=${BUILDDIR}/lib:${BUILDDIR}/lib/.libs:${BUILDDIR}/swig/python/.libs:${BUILDDIR}/glib/.libs::${BUILDDIR}/tcl/.libs
     # We need to put the DLL in PATH for MSYS on Windows
-    if [ ! -z "$MSYSTEM" ]; then
+    elif [ ! -z "$MSYSTEM" ]; then
 	export PATH=${BUILDDIR}/lib:${BUILDDIR}/lib/.libs:$PATH:${BUILDDIR}/swig/python/.libs:${BUILDDIR}/glib/.libs::${BUILDDIR}/tcl/.libs
-    else
+    else  # linux, bsd
 	export LD_LIBRARY_PATH=${BUILDDIR}/lib:${BUILDDIR}/lib/.libs:${BUILDDIR}/swig/python/.libs:${BUILDDIR}/glib/.libs::${BUILDDIR}/tcl/.libs
     fi
     TEST="${PYTHON} ${TEST}"


### PR DESCRIPTION
# [`sigtimedwait (2)`](https://linux.die.net/man/2/sigtimedwait)

Used to clear certain pending signals on unix systems when closing (os funcs?).

No implementation is included in macOS 10.15, 11+, as well as other systems, like Android and OpenBSD [[1]](https://www.gnu.org/software/gnulib/manual/html_node/sigtimedwait.html).

This patch includes a fallback implementation of `sigtimedwait` inspired by

* https://sourceware.org/pipermail/gdb-cvs/2021-July/051027.html (GPL)
* discussion in draft PR #51