### PR TITLE
Add local install folder for binary artifacts

### DIFF
--- a/.github/workflows/winbuild.yml
+++ b/.github/workflows/winbuild.yml
@@ -6,6 +6,9 @@ on:
     tags:
       - v*
 
+env:
+  INSTALLPREFIX: "_local"
+
 jobs:
   mingw-build:
     strategy:
@@ -35,14 +38,12 @@ jobs:
       - name: MSBuild
         run: |
           ./reconf
-          ./configure
+          mkdir $INSTALLPREFIX
+          ./configure --prefix=$(pwd)/$INSTALLPREFIX/
           make
-      - name: Upload binaries from lib and tools
+          make install
+      - name: Upload installed files
         uses: actions/upload-artifact@v3
         with:
           name: gensio-mingw-${{matrix.env}}
-          path: |
-            lib/.libs/*.dll
-            lib/.libs/*.a
-            lib/.libs/*.la
-            tools/*.exe
+          path: ${{ env.INSTALLPREFIX }}/**/*


### PR DESCRIPTION
HI @cminyard,

while testing on Windows I found out that parts of the binary files (located in `tools/.libs` were missing in the artifacts zip. So I changed the workflow by creating a local folder `_local` and installing everything there after build. This folder will then be used for the artifacts zip file and includes now everything which will be installed by the `make install`  routine.

Do you think that this suggestion is sustainable?

Thanks,
Marco