### PR TITLE
Speling

### DIFF
--- a/man/gensio.5
+++ b/man/gensio.5
@@ -737,7 +737,7 @@ The remote ID for the serial dev is the file descriptor returned as an
 integer.
 .SS "Direct Allocation"x
 Allocated as a terminal gensio with gdata as a "const char *" with the
-device and paramters string.
+device and parameters string.
 .SH "stdio"
 accepter =
 .B stdio[(options)]

--- a/man/gensio.5
+++ b/man/gensio.5
@@ -2089,7 +2089,7 @@ used instead of opening a file.
 The readbuf option is not available in this gensio, obviously.
 .SS Options
 .TP
-.b <samplerate>-<channels>-<format>
+.B <samplerate>-<channels>-<format>
 For simple applications, the sound gensio takes a compact and simple
 format as an option.  It specifies those things for both the input and
 output channel.  So, for instance, "sound(44100-2-float)" would be

--- a/man/gensio.5
+++ b/man/gensio.5
@@ -2121,7 +2121,7 @@ Defaults to 100.
 Set the number of input and output channels.  One of these must be
 specified, if you say
 .B chans
-it will set both the input and ouput number of channels.  If you only
+it will set both the input and output number of channels.  If you only
 specify in or out, the other is not enabled.
 .TP
 .B inrate=<n>, outrate=<n>, rate=<n>


### PR DESCRIPTION
This fixes two spelling errors and one mistyped macro in the gensio.5 manpage