### PR TITLE
Ensure that $ax_python_devel_found is defined

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1997,6 +1997,8 @@ if test "x$trypython" = "xyes"; then
       PYTHON_CPPFLAGS="$pythoncflags"
    fi
    AX_PYTHON_DEVEL([], [true])
+else
+   ax_python_devel_found=no
 fi
 if test $ax_python_devel_found = yes; then
    AX_PROG_PYTHON_VERSION([3.0.0],


### PR DESCRIPTION
It might be undefined and in this case triggers an error like:

```
...
checking consistency of all components of python development environment... yes
./configure: line 23729: test: =: unary operator expected
...
```
