### PR TITLE
Revert ax_pkg_swig.m4 to latest vanilla version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1956,21 +1956,19 @@ AC_CHECK_LIB(nsl, main, [HAVE_LIBNSL=1; OSH_LIBS="-lnsl $OSH_LIBS"])
 SWIG_DIR=
 SWIG_CPP_DIR=
 SWIG=
-SWIG_NUMVERSION=0
+available_swig_vernum=0
 if test "x$tryswig" = "xyes"; then
    if test "x$swigprog" != "x"; then
       SWIG="$swigprog"
    fi
-   AX_PKG_SWIG([1.3.21])
-   if test "x$SWIG" != "x"; then
-      AC_DEFINE([HAVE_SWIG], [], [Have swig installed])
-      SWIG_DIR=swig
-      if test $SWIG_NUMVERSION -ge 40100; then
-          SWIG_CPP_DIR=swig
-      else
-          AC_MSG_WARN([SWIG version >= 4.1.0 is required for C++ swig.])
-      fi
-   fi
+   AX_PKG_SWIG(4.1.0,
+        [
+            AC_DEFINE([HAVE_SWIG], [], [Have swig installed])
+            SWIG_DIR=swig
+            SWIG_CPP_DIR=swig
+        ], [
+            AC_MSG_WARN([SWIG version >= 4.1.0 is required for C++ swig.])
+        ])
 fi
 AC_SUBST(SWIG_DIR)
 AC_SUBST(SWIG_CPP_DIR)
@@ -2054,7 +2052,7 @@ AC_SUBST(PYTHON_UNDEF_LIBS)
 PYTHON_EXECUTABLE="${PYTHON}"
 AC_SUBST(PYTHON_EXECUTABLE)
 
-if test $SWIG_NUMVERSION -ge 40100 -a "${enable_shared}" = yes; then
+if test $available_swig_vernum -ge 40100 -a "${enable_shared}" = yes; then
    trygo=yes
 else
    trygo=no
@@ -2075,7 +2073,7 @@ AC_ARG_WITH(go,
    fi,
 )
 
-if test $trygo = yes -a $SWIG_NUMVERSION -lt 40100; then
+if test $trygo = yes -a $available_swig_vernum -lt 40100; then
    AC_MSG_ERROR([Go enabled, but swig version must be >= 4.1.0 for that])
 fi
 GODIR=
@@ -2362,7 +2360,7 @@ pr_op  "  shared libraries:	" $enable_shared
 pr_op  "  sctp sendv:		" $ac_cv_lib_sctp_sctp_sendv
 pr_vop "  python:		" "$ax_python_version"
 if test "$SWIG_CPP_DIR" = "swig"; then
-  prrw "  swig:			" "$SWIG_NUMVERSION"
+  prrw "  swig:			" "$available_swig_vernum"
 else
   prrw "  swig:			" "no"
 fi

--- a/m4/ax_pkg_swig.m4
+++ b/m4/ax_pkg_swig.m4
@@ -19,11 +19,6 @@
 #   1.3.17), AX_PKG_SWIG checks that the swig package is this version number
 #   or higher.
 #
-#   If successful, SWIG_NUMVERSION is set to a numeric value for the
-#   version found in the format NNnnpp where NN is the major version,
-#   nn is the minor version, and pp is the patch version.  This is
-#   easy to directly compare with a number.
-#
 #   As usual, action-if-found is executed if SWIG is found, otherwise
 #   action-if-not-found is executed.
 #
@@ -41,6 +36,8 @@
 #   Copyright (c) 2008 Rafael Laboissiere <rafael@laboissiere.net>
 #   Copyright (c) 2008 Andrew Collier
 #   Copyright (c) 2011 Murray Cumming <murrayc@openismus.com>
+#   Copyright (c) 2018 Reini Urban <rurban@cpan.org>
+#   Copyright (c) 2021 Vincent Danjean <Vincent.Danjean@ens-lyon.org>
 #
 #   This program is free software; you can redistribute it and/or modify it
 #   under the terms of the GNU General Public License as published by the
@@ -68,14 +65,16 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 13
+#serial 15
 
 AC_DEFUN([AX_PKG_SWIG],[
         # Find path to the "swig" executable.
         AC_PATH_PROGS([SWIG],[swig swig3.0 swig2.0])
         if test -z "$SWIG" ; then
                 m4_ifval([$3],[$3],[:])
-        elif test -n "$1" ; then
+        elif test -z "$1" ; then
+                m4_ifval([$2],[$2],[:])
+	else
                 AC_MSG_CHECKING([SWIG version])
                 [swig_version=`$SWIG -version 2>&1 | grep 'SWIG Version' | sed 's/.*\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*/\1/g'`]
                 AC_MSG_RESULT([$swig_version])
@@ -86,12 +85,12 @@ AC_DEFUN([AX_PKG_SWIG],[
                         if test -z "$required_major" ; then
                                 [required_major=0]
                         fi
-                        [required=`echo $required | sed 's/[0-9]*[^0-9]//'`]
+                        [required=`echo $required. | sed 's/[0-9]*[^0-9]//'`]
                         [required_minor=`echo $required | sed 's/[^0-9].*//'`]
                         if test -z "$required_minor" ; then
                                 [required_minor=0]
                         fi
-                        [required=`echo $required | sed 's/[0-9]*[^0-9]//'`]
+                        [required=`echo $required. | sed 's/[0-9]*[^0-9]//'`]
                         [required_patch=`echo $required | sed 's/[^0-9].*//'`]
                         if test -z "$required_patch" ; then
                                 [required_patch=0]
@@ -126,10 +125,9 @@ AC_DEFUN([AX_PKG_SWIG],[
                                 m4_ifval([$3],[$3],[])
                         else
                                 AC_MSG_CHECKING([for SWIG library])
-                                SWIG_LIB=`$SWIG -swiglib | tail -1`
+                                SWIG_LIB=`$SWIG -swiglib | tr '\r\n' '  '`
                                 AC_MSG_RESULT([$SWIG_LIB])
                                 m4_ifval([$2],[$2],[])
-                                SWIG_NUMVERSION=$available_swig_vernum
                         fi
                 else
                         AC_MSG_WARN([cannot determine SWIG version])


### PR DESCRIPTION
And instead of extending the macro, we can use the already create variable 'available_swig_vernum' to compare the required version number.