### PR TITLE
gensiotool: allow building against libressl

### DIFF
--- a/tools/gensiotool.c
+++ b/tools/gensiotool.c
@@ -234,15 +234,23 @@ setup_dummyrand(const char *filename)
  * Set a dummy random input file, for reproducable openssl usage for
  * fuzz testing.
  */
+#include <openssl/opensslv.h>
 #include <openssl/rand.h>
 
 static FILE *dummyrnd_file;
 
+#if defined(LIBRESSL_VERSION_NUMBER)
+static void
+dummyrnd_seed(const void *buf, int num)
+{
+}
+#else
 static int
 dummyrnd_seed(const void *buf, int num)
 {
     return 1;
 }
+#endif
 
 static int
 dummyrnd_bytes(unsigned char *buf, int num)
@@ -274,11 +282,18 @@ dummyrnd_cleanup(void)
 {
 }
 
+#if defined(LIBRESSL_VERSION_NUMBER)
+static void
+dummyrnd_add(const void *buf, int num, double randomness)
+{
+}
+#else
 static int
 dummyrnd_add(const void *buf, int num, double randomness)
 {
     return 1;
 }
+#endif
 
 static int
 dummyrnd_pseudorand(unsigned char *buf, int num)


### PR DESCRIPTION
LibreSSL does not have RAND_set_DRBG_type() and still supports RAND_set_rand_method() which was deprecated in OpenSSL 3.0. Since the code using RAND_set_rand_method() is still present, allow it to build against LibreSSL defining the 'seed' and 'add' functions as returning void in that case.

The same was done for OpenSSL versions older than 1.1.0 before fca23046 ("tools/gensiot: Consolidate dummyrand code"). The check accidentally allowed building against LibreSSL since OPENSSL_VERSION_NUMBER was not defined by including only openssl/rand.h.