### PR TITLE
Two fixes for mdns

### DIFF
--- a/lib/gensio_mdns.c
+++ b/lib/gensio_mdns.c
@@ -880,12 +880,12 @@ mdns_gensio_alloc(const void *gdata, const char * const args[],
 	goto out_base_free;
 
     err = gensio_get_default(o, "mdns", "domain", false,
-			    GENSIO_DEFAULT_STR, &name, NULL);
+			    GENSIO_DEFAULT_STR, &domain, NULL);
     if (err)
 	goto out_base_free;
 
     err = gensio_get_default(o, "mdns", "host", false,
-			    GENSIO_DEFAULT_STR, &type, NULL);
+			    GENSIO_DEFAULT_STR, &host, NULL);
     if (err)
 	goto out_base_free;
 

--- a/lib/gensio_mdns.c
+++ b/lib/gensio_mdns.c
@@ -900,7 +900,7 @@ mdns_gensio_alloc(const void *gdata, const char * const args[],
 	goto out_base_free;
     gensio_msecs_to_time(&timeout, timeoutms);
 
-    if (mstr) {
+    if (mstr && strlen(mstr)) {
 	if (name)
 	    free(name);
 	name = gensio_strdup(o, mstr);


### PR DESCRIPTION
This PR fixes two initialization typos and covers an edge-case when no service name shall be used when connecting via mdns.