### PR TITLE
mdns: add txt filtering option for client connections

### DIFF
--- a/lib/gensio_mdns.c
+++ b/lib/gensio_mdns.c
@@ -52,6 +52,7 @@ struct mdnsn_data {
     char *type;
     char *domain;
     char *host;
+    const char **txt;
 
     bool mdns_in_free;
     struct gensio_mdns *mdns;
@@ -103,6 +104,8 @@ mdnsn_finish_free(struct mdnsn_data *ndata)
 	o->free(o, ndata->domain);
     if (ndata->host)
 	o->free(o, ndata->host);
+    if (ndata->txt)
+	gensio_argv_free(o, ndata->txt);
     if (ndata->deferred_op_runner)
 	o->free_runner(ndata->deferred_op_runner);
     if (ndata->lock)
@@ -323,6 +326,61 @@ addarg(char **args, gensiods *len, struct gensio_os_funcs *o,
 }
 
 static int
+mdns_txt_add_filter(struct gensio_os_funcs *o, const char ***txt,
+		    gensiods *txtargs, gensiods *txtargc,
+		    const char *str)
+{
+    const char *sep;
+    char *txtstr;
+    int err;
+
+    sep = strchr(str, ':');
+    if (!sep || sep == str || sep[1] == '\0')
+	return GE_INVAL;
+
+    txtstr = gensio_alloc_sprintf(o, "%.*s=%s", (int) (sep - str), str,
+				  sep + 1);
+    if (!txtstr)
+	return GE_NOMEM;
+
+    err = gensio_argv_append(o, txt, txtstr, txtargs, txtargc, true);
+    o->free(o, txtstr);
+    return err;
+}
+
+static bool
+mdns_txt_match_one(const char * const *txt, const char *match)
+{
+    unsigned int i;
+
+    if (!txt)
+	return false;
+
+    for (i = 0; txt[i]; i++) {
+	if (strcmp(txt[i], match) == 0)
+	    return true;
+    }
+
+    return false;
+}
+
+static bool
+mdns_txt_matches(const char * const *txt, const char * const *matches)
+{
+    unsigned int i;
+
+    if (!matches)
+	return true;
+
+    for (i = 0; matches[i]; i++) {
+	if (!mdns_txt_match_one(txt, matches[i]))
+	    return false;
+    }
+
+    return true;
+}
+
+static int
 get_mdns_gensiostack(struct mdnsn_data *ndata, const char * const *txt,
 		     const struct gensio_addr *addr, char **rstack)
 {
@@ -522,6 +580,9 @@ mdns_cb(struct gensio_mdns_watch *w,
 	    if (strncmp(buf, "ipv6,fe80:", 10) == 0)
 		goto out_unlock;
 	}
+
+	if (!mdns_txt_matches(txt, ndata->txt))
+	    goto out_unlock;
 
 	if (!ndata->nostack) {
 	    ndata->open_err = get_mdns_gensiostack(ndata, txt, addr, &stack);
@@ -842,6 +903,8 @@ mdns_gensio_alloc(const void *gdata, const char * const args[],
     gensiods max_read_size = GENSIO_DEFAULT_BUF_SIZE;
     char *laddr = NULL, *name = NULL, *type = NULL;
     char *domain = NULL, *host = NULL, *nettype_str = NULL;
+    const char **txt = NULL;
+    gensiods txtargs = 0, txtargc = 0;
     bool nodelay = false, readbuf_set = false, nodelay_set = false;
     bool ignore_v6_link_local = false;
     const char *str;
@@ -978,6 +1041,16 @@ mdns_gensio_alloc(const void *gdata, const char * const args[],
 	    }
 	    continue;
 	}
+	if (gensio_pparm_value(&p, args[i], "txt", &str) > 0) {
+	    err = mdns_txt_add_filter(o, &txt, &txtargs, &txtargc, str);
+	    if (err == GE_INVAL)
+		gensio_pparm_log(&p,
+		                 "Invalid txt filter '%s', expected key:value\n",
+		                 str);
+	    if (err)
+		goto out_base_free;
+	    continue;
+	}
 	if (gensio_pparm_value(&p, args[i], "nettype", &str) > 0) {
 	    if (nettype_str)
 		free(nettype_str);
@@ -1009,6 +1082,12 @@ mdns_gensio_alloc(const void *gdata, const char * const args[],
     o->free(o, nettype_str);
     nettype_str = NULL;
 
+    if (txt) {
+	err = gensio_argv_append(o, &txt, NULL, &txtargs, &txtargc, false);
+	if (err)
+	    goto out_base_free;
+    }
+
     err = mdns_ndata_setup(o, max_read_size, nodelay, interface, nettype,
 			   nostack, &ndata);
     if (err)
@@ -1022,6 +1101,7 @@ mdns_gensio_alloc(const void *gdata, const char * const args[],
     ndata->type = type;
     ndata->domain = domain;
     ndata->host = host;
+    ndata->txt = txt;
     ndata->timeout = timeout;
 
     ndata->io = gensio_data_alloc(ndata->o, cb, user_data,
@@ -1049,6 +1129,8 @@ mdns_gensio_alloc(const void *gdata, const char * const args[],
 	o->free(o, domain);
     if (host)
 	o->free(o, host);
+    if (txt)
+	gensio_argv_free(o, txt);
     if (nettype_str)
 	o->free(o, nettype_str);
     return err;

--- a/lib/gensio_mdns.c
+++ b/lib/gensio_mdns.c
@@ -515,8 +515,9 @@ mdns_timeout(struct gensio_timer *timer, void *cb_data)
     switch (ndata->state) {
     case MDNSN_IN_OPEN_QUERY:
 	ndata->open_err = GE_NOTFOUND;
+	mdnsn_deref(ndata);
 	mdns_handle_err(ndata);
-	break;
+	return;
 
     case MDNSN_IN_CLOSE:
 	/* Maybe we should finish the close. */

--- a/man/gensio.5
+++ b/man/gensio.5
@@ -2012,6 +2012,12 @@ Set the mdns domain to search for.  You generally don't use this.
 .B host=<mdnsstr>
 Set the mdns host to search for.  You generally don't use this.
 .TP
+.B txt=<key>:<value>
+Require the service to have a TXT record matching the given key and
+value.  This is an exact match against the standard mDNS TXT
+\fIkey=value\fR entry.  You may specify this option multiple times; all
+specified TXT entries must be present on the same service.
+.TP
 .B interface=<num>
 Set the network interface number to search on.  The default is -1,
 which means all interfaces.

--- a/tests/test_mdns.py
+++ b/tests/test_mdns.py
@@ -97,6 +97,19 @@ class mdns_handler:
     def wait(self):
         return self.waiter.wait_timeout(1, 10000)
 
+def test_mdns_connect_fail(iostr, expect_err):
+    io = gensio.gensio(utils.o, iostr, None)
+    try:
+        io.open_s()
+    except Exception as e:
+        err = str(e)
+        if expect_err not in err:
+            raise Exception("Open error '%s' did not contain '%s'" %
+                            (err, expect_err))
+    else:
+        raise Exception("Expected open failure")
+    del io
+
 print("Testing mdns")
 c = mdns_closer()
 e = mdns_handler()
@@ -155,6 +168,20 @@ w.wait_timeout(1, 1000)
 
 utils.TestAccept(utils.o, "mdns(type=_gensiotest._tcp,ignore-v6-link-local)," +
                           "gensiotest_service",
+                 "tcp,5096", utils.do_small_test, chunksize = 64, get_port=False)
+
+print("  TXT filter connect")
+utils.TestAccept(utils.o, "mdns(type=_gensiotest._tcp,txt=Hello:yes)," +
+                          "gensiotest_service",
+                 "tcp,5096", utils.do_small_test, chunksize = 64, get_port=False)
+
+print("  TXT filter mismatch")
+test_mdns_connect_fail("mdns(type=_gensiotest._tcp,txt=Hello:no," +
+                       "mdnstimeout=500),gensiotest_service", "not found")
+
+print("  Multiple TXT filters")
+utils.TestAccept(utils.o, "mdns(type=_gensiotest._tcp,txt=Hello:yes," +
+                          "txt=Goodbye:no),gensiotest_service",
                  "tcp,5096", utils.do_small_test, chunksize = 64, get_port=False)
 
 del mdns


### PR DESCRIPTION
Sometimes there are multiple devices using the same mDNS instance name on the network. Then the name is not stable due to conflict resolution and it is thus not really usable.

However, when unique text records are present, it is possible to filter for them. This change implements this and makes it for example possible to use:

  gensiot 'mdns(type=_console._tcp,txt=serial:1234)'

I used the ':' character to split the mDNS txt key and value, to keep the existing parsing. It is also possible to specify more than one txt filter, then all must match (AND logic).